### PR TITLE
Pass the SNMP trap port number and IP-address in network-endian format

### DIFF
--- a/include/lwip/apps/snmp_opts.h
+++ b/include/lwip/apps/snmp_opts.h
@@ -39,6 +39,8 @@
 
 #include "lwip/opt.h"
 
+#include <arpa/inet.h>
+
 /**
  * @defgroup snmp_opts Options
  * @ingroup snmp

--- a/include/lwip/opt.h
+++ b/include/lwip/opt.h
@@ -132,4 +132,6 @@ extern struct netif *netif_list;
   LWIP_PLATFORM_ERROR(message); handler;}} while(0)
 #endif /* LWIP_ERROR */
 
+const char * print_oid (size_t oid_len, const u32_t *oid_words);
+
 #endif /* LWIP_OPT_H */

--- a/src/snmp_traps.c
+++ b/src/snmp_traps.c
@@ -319,8 +319,10 @@ snmp_send_msg(struct snmp_msg_trap *trap_msg, struct snmp_varbind *varbinds, u16
     snmp_stats.outtraps++;
     snmp_stats.outpkts++;
 
+    /* snmp_sendto() wants a network-endian port number. */
+    u16_t port = ntohs(LWIP_IANA_PORT_SNMP_TRAP);
     /** send to the TRAP destination */
-    rc = snmp_sendto(snmp_traps_handle, p, dip, LWIP_IANA_PORT_SNMP_TRAP);
+    rc = snmp_sendto(snmp_traps_handle, p, dip, port);
     if (rc <= 0) {
 		err = ERR_CONN;
 	}


### PR DESCRIPTION
The function `snmp_sendto()` expects a port number in network-endian format. Before this PR, `snmp_sendto()` was called with port `LWIP_IANA_PORT_SNMP_TRAP`, which is 162.
