### PR TITLE
Removed the check about the network, added snmp_zephyr.h

### DIFF
--- a/include/lwip/apps/snmp.h
+++ b/include/lwip/apps/snmp.h
@@ -66,14 +66,17 @@ struct snmp_varbind
   /** object value length */
   u16_t value_len;
   /** object value */
-  void *value;
+  /** _HT_ changed the meaningless and overused 'value'
+   * into a unique identifier 'object_value'.
+   */
+  void *object_value;
 };
 
 /**
  * @ingroup snmp_core
  * Agent setup, start listening to port 161.
  */
-void snmp_init(void);
+int snmp_init(void);
 void snmp_set_mibs(const struct snmp_mib **mibs, u8_t num_mibs);
 
 void snmp_set_device_enterprise_oid(const struct snmp_obj_id* device_enterprise_oid);

--- a/include/lwip/apps/snmp_core.h
+++ b/include/lwip/apps/snmp_core.h
@@ -185,8 +185,9 @@ typedef enum {
 } snmp_access_t;
 
 struct snmp_node_instance;
-
-typedef s16_t (*node_instance_get_value_method)(struct snmp_node_instance*, void*);
+struct snmp_varbind;
+/* Code related to the SNMP call-back mechanism. */
+typedef s16_t (*node_instance_get_value_method)(struct snmp_node_instance*, struct snmp_varbind*);
 typedef snmp_err_t (*node_instance_set_test_method)(struct snmp_node_instance*, u16_t, void*);
 typedef snmp_err_t (*node_instance_set_value_method)(struct snmp_node_instance*, u16_t, void*);
 typedef void (*node_instance_release_method)(struct snmp_node_instance*);

--- a/include/lwip/apps/snmp_scalar.h
+++ b/include/lwip/apps/snmp_scalar.h
@@ -79,7 +79,12 @@ struct snmp_scalar_array_node_def
   snmp_access_t access;
 };
 
-typedef s16_t (*snmp_scalar_array_get_value_method)(const struct snmp_scalar_array_node_def*, void*);
+/* snmp_scalar_array_get_value() will now get a pointer to the snmp_varbind,
+ * in order to get the entire OID.
+ * If a matching handler is found, it will be called. The value will be set
+ * in vb->object_value, and the number of bytes written is returned (16 or 32).
+ */
+typedef s16_t (*snmp_scalar_array_get_value_method)(const struct snmp_scalar_array_node_def*, struct snmp_varbind *);
 typedef snmp_err_t (*snmp_scalar_array_set_test_method)(const struct snmp_scalar_array_node_def*, u16_t, void*);
 typedef snmp_err_t (*snmp_scalar_array_set_value_method)(const struct snmp_scalar_array_node_def*, u16_t, void*);
 

--- a/include/lwip/apps/snmp_zephyr.h
+++ b/include/lwip/apps/snmp_zephyr.h
@@ -15,6 +15,17 @@ extern void snmp_init(void);
  */
 extern void snmp_loop(void);
 
+/**
+ * Sets the IP-address for the next trap.
+ */
+extern void snmp_prepare_trap_test(const char * ip_address);
+
+/**
+ * Takes an array of integeres as an input, and returns a
+ * human readble string like eg. "1.3.6.1.4.1.62530.2.10.15".
+ */
+const char * print_oid (size_t oid_len, const u32_t *oid_words);
+
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/lwip/apps/snmp_zephyr.h
+++ b/include/lwip/apps/snmp_zephyr.h
@@ -1,0 +1,17 @@
+#ifndef __SNMP_ZEPHYR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Starts SNMP Agent.
+ */
+extern void snmp_init(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif
+

--- a/include/lwip/apps/snmp_zephyr.h
+++ b/include/lwip/apps/snmp_zephyr.h
@@ -9,6 +9,13 @@ extern "C" {
  */
 extern void snmp_init(void);
 
+/**
+ * handle incomming requests.
+ * A call-back will be generated when necessary.
+ */
+extern void snmp_loop(void);
+
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/include/lwip/apps/snmp_zephyr.h
+++ b/include/lwip/apps/snmp_zephyr.h
@@ -1,3 +1,8 @@
+/**
+ * @file
+ * SNMP zephyr frontend.
+ */
+
 #ifndef __SNMP_ZEPHYR_H
 
 #ifdef __cplusplus
@@ -5,31 +10,75 @@ extern "C" {
 #endif
 
 /**
- * Starts SNMP Agent.
+ * @brief Definition of a callback function.
+ *
+ * @param[in] oid The current OID that is requested.
+ * @param[in] entry A struct with information about this call-back.
+ *
+ * @return The return value of the handler will be sent to the requester.
  */
-extern void snmp_init(void);
+struct snmp_handler_entry;
+typedef int (*snmp_handler)(const char *oid, struct snmp_handler_entry * entry);
 
 /**
- * handle incomming requests.
- * A call-back will be generated when necessary.
+ * @brief Definition of a callback entry.
+ *
+ */
+struct snmp_handler_entry {
+  snmp_handler handler;            /**< The function that will be called. */
+  const char *prefix;              /**< The IOD for which it will be called. */
+  struct snmp_handler_entry *next; /**< The next handler in an array. */
+};
+
+/**
+ * @brief Try to match an OID with the installed handlers.
+ *        When a match is found, call the handler function.
+ *        This function is private and should only be called from
+ *        the SNMP library.
+ */
+size_t snmp_private_call_handler(const char *prefix, void *value);
+
+/**
+ * @brief Install a new SNMP callback function.
+ *
+ * @param[in] entry A description of the new callback.
+ */
+void install_snmp_handler(struct snmp_handler_entry * entry);
+
+/**
+ * @brief Starts SNMP Agent. It assumes that the network is up and
+ *        running. The UDP sockets will be created.
+ */
+extern int snmp_init(void);
+
+/**
+ * @brief handle incomming requests.
+ *        A call-back will be executed when necessary.
  */
 extern void snmp_loop(void);
 
 /**
- * Sets the IP-address for the next trap.
+ * @brief Sets the IP-address for the next trap.
+ *
+ * @param[in] ip_address A string representation of the IP-address.
  */
-extern void snmp_prepare_trap_test(const char * ip_address);
+extern void snmp_prepare_trap_test(const char *ip_address);
+
+void snmp_install_handlers(void);
 
 /**
- * Takes an array of integeres as an input, and returns a
- * human readble string like eg. "1.3.6.1.4.1.62530.2.10.15".
+ * @brief Converts an array of integeres to a human-readable
+ *        character string, representing the OID.
+ *
+ * @param[in] oid_len The number of integeres in the parameter oid_words
+ * @param[in] oid_words The array of integer values
  */
-const char * print_oid (size_t oid_len, const u32_t *oid_words);
+const char *print_oid(size_t oid_len, const u32_t *oid_words);
 
+size_t zephyr_log( const char * format, ... );
 
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
 
 #endif
-

--- a/include/lwip/opt.h
+++ b/include/lwip/opt.h
@@ -134,4 +134,7 @@ extern struct netif *netif_list;
 
 const char * print_oid (size_t oid_len, const u32_t *oid_words);
 
+/* The following function is "private", it will be called by the SNMP stack. */
+size_t snmp_private_call_handler(const char *prefix, void *value);
+
 #endif /* LWIP_OPT_H */

--- a/src/snmp_core.c
+++ b/src/snmp_core.c
@@ -186,6 +186,7 @@
 
 #include "lwip/apps/snmp.h"
 #include "lwip/apps/snmp_core.h"
+#include "lwip/apps/snmp_scalar.h"
 #include "snmp_core_priv.h"
 #include "lwip/netif.h"
 #include <string.h>
@@ -806,6 +807,9 @@ snmp_get_node_instance_from_oid(const u32_t *oid, u8_t oid_len, struct snmp_node
       }
 #endif
     }
+  } else {
+	/** No mib was found describing the given OID.
+	 */
   }
 
   return result;

--- a/src/snmp_traps.c
+++ b/src/snmp_traps.c
@@ -287,7 +287,7 @@ snmp_prepare_necessary_msg_fields(struct snmp_msg_trap *trap_msg, const struct s
     MIB2_COPY_SYSUPTIME_TO(&trap_msg->ts);
   } else if (trap_msg->snmp_version == SNMP_VERSION_2c) {
     /* Copy sysUpTime into the first varbind */
-    MIB2_COPY_SYSUPTIME_TO((u32_t *)varbinds[0].value);
+    MIB2_COPY_SYSUPTIME_TO((u32_t *)varbinds[0].object_value);
   }
 }
 
@@ -303,12 +303,12 @@ snmp_prepare_necessary_msg_fields(struct snmp_msg_trap *trap_msg, const struct s
 static err_t
 snmp_send_msg(struct snmp_msg_trap *trap_msg, struct snmp_varbind *varbinds, u16_t tot_len, ip_addr_t *dip)
 {
+  int rc;
   err_t err = ERR_OK;
   struct pbuf *p = NULL;
   /* allocate pbuf(s) */
   p = pbuf_alloc(PBUF_TRANSPORT, tot_len, PBUF_RAM);
   if (p != NULL) {
-    int rc;
     struct snmp_pbuf_stream pbuf_stream;
     snmp_pbuf_stream_init(&pbuf_stream, p, 0, tot_len);
 
@@ -399,7 +399,7 @@ snmp_send_trap_or_notification_or_inform_generic(struct snmp_msg_trap *trap_msg,
   snmp_v2_special_varbinds[0].next = &snmp_v2_special_varbinds[1];
   snmp_v2_special_varbinds[1].prev = &snmp_v2_special_varbinds[0];
 
-  snmp_v2_special_varbinds[0].value = &timestamp;
+  snmp_v2_special_varbinds[0].object_value = &timestamp;
 
   snmp_v2_special_varbinds[1].next = varbinds;
 
@@ -409,7 +409,7 @@ snmp_send_trap_or_notification_or_inform_generic(struct snmp_msg_trap *trap_msg,
     err = snmp_prepare_trap_oid(&snmp_trap_oid, eoid, generic_trap, specific_trap);
     if (err == ERR_OK) {
       snmp_v2_special_varbinds[1].value_len = snmp_trap_oid.len * sizeof(snmp_trap_oid.id[0]);
-      snmp_v2_special_varbinds[1].value = snmp_trap_oid.id;
+      snmp_v2_special_varbinds[1].object_value = snmp_trap_oid.id;
       if (varbinds != NULL) {
         original_prev = varbinds->prev;
         varbinds->prev = &snmp_v2_special_varbinds[1];

--- a/src/snmp_zephyr.c
+++ b/src/snmp_zephyr.c
@@ -255,6 +255,17 @@
 			socket_set.timeout.tv_sec = 0;
 			socket_set.timeout.tv_usec = 1000U;
 			has_sockets = (socket_set.socket_161 >= 0) && (socket_set.socket_162 >= 0);
+			if (has_sockets == 0) {
+				/* We're not going to run with just 1 socket. */
+				if (socket_set.socket_161 >= 0) {
+					zsock_close(socket_set.socket_161);
+					socket_set.socket_161 = -1;
+				}
+				if (socket_set.socket_162 >= 0) {
+					zsock_close(socket_set.socket_162);
+					socket_set.socket_162 = -1;
+				}
+			}
 		}
 		first_handler = NULL;
 		return has_sockets;

--- a/src/snmp_zephyr.c
+++ b/src/snmp_zephyr.c
@@ -220,7 +220,7 @@
 									  0, // flags
 									  &client_addr,
 									  &client_addr_len );
-				if (len > 0) {
+				if (len > 0 && index < 2) {
 					int port = (index == 0) ? 161 : 162;
 					zephyr_log( "recv[%u]: %d bytes from %s:%u\n",
 						 port,
@@ -318,6 +318,8 @@
 		}
 	}
 
+	/* As part of the zephyr "port", we must define some
+	 * memory allocation. */
 	void * mem_malloc( mem_size_t size )
 	{
 		return k_malloc( size );

--- a/src/snmp_zephyr.c
+++ b/src/snmp_zephyr.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * SNMP netconn frontend.
+ * SNMP zephyr frontend.
  */
 
 /*
@@ -37,18 +37,8 @@
 #include <errno.h>
 #include <stdarg.h>
 
-#ifndef __ZEPHYR__
-
-	#include <netinet/in.h>
-	#include <sys/socket.h>
-	#include <unistd.h>
-
-#else
-
-	#include <zephyr/net/socket.h>
-	#include <zephyr/kernel.h>
-
-#endif
+#include <zephyr/net/socket.h>
+#include <zephyr/kernel.h>
 
 #include <arpa/inet.h>
 #include <sys/select.h>
@@ -87,6 +77,9 @@
 /** Yes, a global variable. */
 	struct udp_pcb * udp_pcbs;
 
+/** The first entry in a liinked list of handler entries. */
+	static struct snmp_handler_entry * first_handler;
+
 /** Global variable containing lwIP internal statistics. Add this to your debugger's watchlist. */
 	struct stats_ lwip_stats;
 
@@ -96,12 +89,10 @@
 /** The default network interface. */
 	struct netif * netif_default;
 
-	static void go_sleep();
-
-/** Wake up the thread 'z_snmp_client' in order to send a trap. */
-	void snmp_send_zbus(void);
-
 	static socket_set_t socket_set;
+
+/** 'has_sockets' is true when all UD sockets are created. */
+	static bool has_sockets = 0;
 
 	#define CHAR_BUF_LEN  512 /* declared on the heap at first time use. */
 	char char_buffer[CHAR_BUF_LEN];
@@ -125,7 +116,6 @@
 		if( socket_fd < 0 )
 		{
 			zephyr_log( "create_socket: error: socket: %d errno: %d\n", socket_fd, errno );
-			go_sleep( 1 );
 		}
 		else
 		{
@@ -158,7 +148,6 @@
 			if( zsock_bind( socket_fd, ( struct sockaddr * ) &bind_addr, sizeof( bind_addr ) ) < 0 )
 			{
 				zephyr_log( "create_socket: bind: %d\n", errno );
-				go_sleep( 1 );
 			}
 		}
 		return socket_fd;
@@ -180,16 +169,6 @@
 		snmp_trap_dst_ip_set(0, &dst);
 	}
 
-	static int max_int(int left, int right)
-	{
-		int rc = left;
-		if (right > rc)
-		{
-			rc = right;
-		}
-		return rc;
-	}
-
 	/**
 	 * @brief Check all open sockets and answer get request, get next, etc.
 	 *         The call will block for 10 ms, see socket_set.timeout.
@@ -197,63 +176,70 @@
 
 	void snmp_loop()
 	{
-		int rc_select;
-		fd_set read_set; /* A set of file descriptors. */
-		FD_ZERO(&read_set);
-		FD_SET(socket_set.socket_161, &read_set);
-		FD_SET(socket_set.socket_162, &read_set);
-		socket_set.select_max = max_int(socket_set.socket_161, socket_set.socket_162) + 1;
+		int rc_poll;
 
-		rc_select = select(socket_set.select_max, &read_set, NULL, NULL, &(socket_set.timeout));
-		if (rc_select > 0) for (int index = 0; index < 2; index++)
+		if (!has_sockets) {
+			k_sleep(K_MSEC(5));
+			return;
+		}
+		struct pollfd fds[2];
+		
+		// Configure pollfd for UDP socket 161
+		fds[0].fd = socket_set.socket_161;
+		fds[0].events = POLLIN;
+		
+		// Configure pollfd for UDP socket 162
+		fds[1].fd = socket_set.socket_162;
+		fds[1].events = POLLIN;
+
+		rc_poll = poll(fds, 2, 200); // Wait 200 ms
+
+		if (rc_poll > 0) for (int index = 0; index < 2; index++)
 		{
 			int udp_socket = (index == 0) ? socket_set.socket_161 : socket_set.socket_162;
-			if (FD_ISSET(udp_socket, &read_set))
+			struct sockaddr client_addr;
+			struct sockaddr_in * sin = (struct sockaddr_in *) &client_addr;
+			socklen_t client_addr_len = sizeof client_addr;
+			int len;
+			len = zsock_recvfrom( udp_socket,
+								  char_buffer,
+								  sizeof char_buffer,
+								  0, // flags
+								  &client_addr,
+								  &client_addr_len );
+			if (len > 0 && index < 2) {
+				int port = (index == 0) ? 161 : 162;
+				zephyr_log( "recv[%u]: %d bytes from %s:%u\n",
+					 port,
+					 len,
+					 inet_ntoa(sin->sin_addr),
+					 ntohs(sin->sin_port));
+			}
+			if (len > 0) //  && index == 0)
 			{
-				struct sockaddr client_addr;
-				struct sockaddr_in * sin = (struct sockaddr_in *) &client_addr;
-				socklen_t client_addr_len = sizeof client_addr;
-				int len;
-				len = zsock_recvfrom( udp_socket,
-									  char_buffer,
-									  sizeof char_buffer,
-									  0, // flags
-									  &client_addr,
-									  &client_addr_len );
-				if (len > 0 && index < 2) {
-					int port = (index == 0) ? 161 : 162;
-					zephyr_log( "recv[%u]: %d bytes from %s:%u\n",
-						 port,
-						 len,
-						 inet_ntoa(sin->sin_addr),
-						 ntohs(sin->sin_port));
-				}
-				if (len > 0) //  && index == 0)
+				struct pbuf * pbuf = pbuf_alloc( PBUF_TRANSPORT, len, PBUF_RAM );
+
+				if( pbuf != NULL )
 				{
-					struct pbuf * pbuf = pbuf_alloc( PBUF_TRANSPORT, len, PBUF_RAM );
+					pbuf->next = NULL;
+					memcpy( pbuf->payload, char_buffer, len );
+					pbuf->tot_len = len;
+					pbuf->len = len;
+					pbuf->ref = 1;
 
-					if( pbuf != NULL )
-					{
-						pbuf->next = NULL;
-						memcpy( pbuf->payload, char_buffer, len );
-						pbuf->tot_len = len;
-						pbuf->len = len;
-						pbuf->ref = 1;
-
-						ip_addr_t from_address;
-						from_address.addr = sin->sin_addr.s_addr;
-						snmp_receive( (void*) udp_socket, pbuf, &from_address, sin->sin_port);
-						pbuf_free (pbuf);
-					}
-				} /* if (len > 0 && index == 0) */
-			} /* FD_ISSET */
+					ip_addr_t from_address;
+					from_address.addr = sin->sin_addr.s_addr;
+					snmp_receive( (void*) udp_socket, pbuf, &from_address, sin->sin_port);
+					pbuf_free (pbuf);
+				}
+			} /* if (len > 0 && index == 0) */
 		} /* for (int index = 0 */
 	}
 
 /**
- * @brief Starts SNMP Agent.
+ * @brief Create sockets, starts SNMP Agent.
  */
-	void snmp_init(void)
+	int snmp_init(void)
 	{
 		static int has_created = false;
 		if (has_created == false) {
@@ -267,8 +253,11 @@
 			snmp_traps_handle = ( void * ) socket_set.socket_162;
 
 			socket_set.timeout.tv_sec = 0;
-			socket_set.timeout.tv_usec = 10000U;
+			socket_set.timeout.tv_usec = 1000U;
+			has_sockets = (socket_set.socket_161 >= 0) && (socket_set.socket_162 >= 0);
 		}
+		first_handler = NULL;
+		return has_sockets;
 	}
 
 	/* send a UDP packet to the LAN using a network-endian
@@ -418,4 +407,75 @@ const char *leafNodeName (unsigned aType)
 	case SNMP_NODE_THREADSYNC:   return "Threadsync";   // 0x04
 	}
 	return "Unknown";
+}
+
+/*
+ *       ####          ###   ###   ##                     ##
+ *      #    #           #     #    #                      #
+ *     #     #           #     #    #                      #
+ *     #        ####     #     #    #####   ####    ####   #    #
+ *     #            #    #     #    #    #      #  #   ##  #   #
+ *     #        #####    #     #    #    #  #####  #       ####
+ *     #     # #    #    #     #    #    # #    #  #       #   #
+ *      #    # #    #    #     #    #    # #    #  #   ##  #    #
+ *       ####   ### ## ##### ##### ## ###   ### ##  ####  ##   ##
+ */
+
+static int match_length(const char *complete, const char *partial)
+{
+	int index;
+	for (index = 0; ; index++) {
+		char ch0 = complete[index];
+		char ch1 = partial[index];
+		if (!ch0 || !ch1) {
+			break;
+		}
+		if (ch0 != ch1) {
+			break;
+		}
+	}
+	return index;
+}
+
+void install_snmp_handler(struct snmp_handler_entry * new_entry)
+{
+	new_entry->next = NULL;
+	if (first_handler == NULL) {
+		first_handler = new_entry;
+	} else {
+		struct snmp_handler_entry * current = first_handler;
+		for (;;) {
+			/* assert that 'current != NULL ' */
+			if (current->next == NULL) {
+				current->next = new_entry;
+				break;
+			}
+			current = current->next;
+		}
+	}
+}
+
+size_t snmp_private_call_handler(const char *prefix, void *value_p)
+{
+	int value_length = 0;
+	struct snmp_handler_entry *entry = first_handler;
+	size_t plength = strlen (prefix);
+	/* 'value_p' points to an array of SNMP_VALUE_BUFFER_SIZE bytes. */
+	zephyr_log("snmp_private_call_handler: Looking for %s\n", prefix);
+
+	while (entry != NULL) {
+		if (entry->handler) {
+			int mlength = match_length(entry->prefix, prefix);
+			zephyr_log("Match \"%s\" %d/%d\n", entry->prefix, mlength, plength);
+			if (mlength >= plength || mlength == strlen (entry->prefix)) {
+				int value = entry->handler(prefix, entry);
+				value_length = sizeof value;
+				memcpy (value_p, &value, value_length);
+				break;
+			}
+		}
+		entry = entry->next;
+	}
+	zephyr_log ("snmp_private_call_handler (%s): %sfound\n", prefix, entry ? "" : "not ");
+	return value_length;
 }

--- a/src/snmp_zephyr.c
+++ b/src/snmp_zephyr.c
@@ -59,7 +59,7 @@
 #include <app_version.h>
 
 #include "lwip/apps/snmp_opts.h"
-#include "lwip/apps/zenmp_zephyr.h"
+#include "lwip/apps/snmp_zephyr.h"
 
 #if LWIP_SNMP && SNMP_USE_ZEPHYR
 
@@ -190,6 +190,11 @@
 		return rc;
 	}
 
+	/**
+	 * @brief Check all open sockets and answer get request, get next, etc.
+	 *         The call will block for 10 ms, see socket_set.timeout.
+	 */
+
 	void snmp_loop()
 	{
 		int rc_select;
@@ -210,11 +215,11 @@
 				socklen_t client_addr_len = sizeof client_addr;
 				int len;
 				len = zsock_recvfrom( udp_socket,
-								char_buffer,
-								sizeof char_buffer,
-								0, // flags
-								&client_addr,
-								&client_addr_len );
+									  char_buffer,
+									  sizeof char_buffer,
+									  0, // flags
+									  &client_addr,
+									  &client_addr_len );
 				if (len > 0) {
 					int port = (index == 0) ? 161 : 162;
 					zephyr_log( "recv[%u]: %d bytes from %s:%u\n",
@@ -246,7 +251,7 @@
 	}
 
 /**
- * Starts SNMP Agent.
+ * @brief Starts SNMP Agent.
  */
 	void snmp_init(void)
 	{


### PR DESCRIPTION
As the title says, removed the check about the network, a function called `wait_for_ethernet()`.
So when the function `snmp_init()` is called, it is assumed that the network is up.

Added the `zsock_` prefix before all BSD calls like eg. `zsock_setsockopt()` and `zsock_recv()`.

Added `include/lwip/apps/snmp_zephyr.h`. For the moment it only contains:
~~~
 /**
 * Starts SNMP Agent.
 */
extern void snmp_init(void);
~~~
