### PR TITLE
Remove the compiler warning from CMakeList.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,4 @@ zephyr_library_sources(
   src/snmpv3_priv.h
 )
 
-target_compile_options(app PRIVATE -Wall -Wextra -Wpointer-arith)
-
 endif (CONFIG_LIB_SNMP)


### PR DESCRIPTION
In my last PR, I added a line in CMakeLists.txt which would enable all possible warning. That was for private use only. Hereby reverted.