### PR TITLE
Made CHANGELOG up-to-date, and completed MIB2 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,39 +16,18 @@ and this project adheres to
 
 - move to a callback for SNMP get requests
 
-## [v0.0.1] 2025-01-06
+## [v0.0.1] - 2025-04-27
 
-- PR #1 from added_header_files
-- Added the necessary header files from the latest lwIP release, also started to port the software for Zypher, using it native IP-stack.
-- Adapted opt.h to make things compiling and running.
-- TODO: porting code should appear in lwipopts.h
+- Tested the MIB's and library by running an SNMP walk. This command iterates through all entries, starting at a certain point, eg. '1':
+  Command: `snmpwalk -v2c -c public 192.168.2.17 1`
+  It provides an interesting extra test.
 
-## [v0.0.1] 2025-01-15
+## [v0.0.1] - 2025-04-24
 
-- #3 from Better_logging_snmp_zephyr
-- Made logging better by showing request OID (Object ID) of requests.
+- #10 from remove_compiler_warning_changes
+- Remove the compiler warning from CMakeList.txt
 
-## [v0.0.1] 2025-01-29
-
-- #5 from More_logging_more_tested
-- Tested sending traps, also tested the new functions in snmp_zephyr.c
-
-## [v0.0.1] 2025-02-25
-
-- #6 from pass_address_network_endian
-- Pass the SNMP trap port number and IP-address in network-endian format
-
-## [v0.0.1] 2025-03-13
-
-- #7 from assume_network_ready_while_init
-- Assume that the zephyr network is up-and-running at start-up. Until now this seems to work OK.
-
-## [v0.0.1] 2025-03-13
-
-- #8 from Worked_on_snmp_zephyr
-- Removed the check about the network, added snmp_zephyr.h
-
-## [v0.0.1] 2025-04-22
+## [v0.0.1] - 2025-04-22
 
 - #9 from Start_using_socket_service
 - The SNMP port started using the Zephyr socket services
@@ -56,16 +35,36 @@ and this project adheres to
 - The socket services will pass UDP data to the SNMP thread, which will execute the commands and give a reply. The sending of traps happens in the same thread, thus avoiding things like: race conditions, data races, deadlocks and synchronisation errors.
 - And also in this big PR: a call-back system was developed.
 
-## [v0.0.1] 2025-04-24
+## [v0.0.1] - 2025-03-13
 
-- #10 from remove_compiler_warning_changes
-- Remove the compiler warning from CMakeList.txt
+- #8 from Worked_on_snmp_zephyr
+- Removed the check about the network, added snmp_zephyr.h
 
-## [v0.0.1] 2025-04-27
+## [v0.0.1] - 2025-03-13
 
-- The script `snmp_test.sh` gets a 3th test:
-1. Reply to SNMP get request to read the A/B status
-2. Do a complete SNMP walk to see if the data structures are OK [new]
-3. Check if the proper traps are being sent when A/B status changes
+- #7 from assume_network_ready_while_init
+- Assume that the zephyr network is up-and-running at start-up. Until now this seems to work OK.
+
+## [v0.0.1] - 2025-02-25
+
+- #6 from pass_address_network_endian
+- Pass the SNMP trap port number and IP-address in network-endian format
+
+## [v0.0.1] - 2025-01-29
+
+- #5 from More_logging_more_tested
+- Tested sending traps, also tested the new functions in snmp_zephyr.c
+
+## [v0.0.1] - 2025-01-15
+
+- #3 from Better_logging_snmp_zephyr
+- Made logging better by showing request OID (Object ID) of requests.
+
+## [v0.0.1] - 2025-01-06
+
+- PR #1 from added_header_files
+- Added the necessary header files from the latest lwIP release, also started to port the software for Zypher, using it native IP-stack.
+- Adapted opt.h to make things compiling and running.
+- TODO: porting code should appear in lwipopts.h
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,57 @@ and this project adheres to
 ## [v0.0.2] - 2025-04-23
 
 - move to a callback for SNMP get requests
+
+## [v0.0.1] 2025-01-06
+
+- PR #1 from added_header_files
+- Added the necessary header files from the latest lwIP release, also started to port the software for Zypher, using it native IP-stack.
+- Adapted opt.h to make things compiling and running.
+- TODO: porting code should appear in lwipopts.h
+
+## [v0.0.1] 2025-01-15
+
+- #3 from Better_logging_snmp_zephyr
+- Made logging better by showing request OID (Object ID) of requests.
+
+## [v0.0.1] 2025-01-29
+
+- #5 from More_logging_more_tested
+- Tested sending traps, also tested the new functions in snmp_zephyr.c
+
+## [v0.0.1] 2025-02-25
+
+- #6 from pass_address_network_endian
+- Pass the SNMP trap port number and IP-address in network-endian format
+
+## [v0.0.1] 2025-03-13
+
+- #7 from assume_network_ready_while_init
+- Assume that the zephyr network is up-and-running at start-up. Until now this seems to work OK.
+
+## [v0.0.1] 2025-03-13
+
+- #8 from Worked_on_snmp_zephyr
+- Removed the check about the network, added snmp_zephyr.h
+
+## [v0.0.1] 2025-04-22
+
+- #9 from Start_using_socket_service
+- The SNMP port started using the Zephyr socket services
+- This makes it possible to have the SNMP thread sleep in a central place and with the `K_FOREVER` parameter.
+- The socket services will pass UDP data to the SNMP thread, which will execute the commands and give a reply. The sending of traps happens in the same thread, thus avoiding things like: race conditions, data races, deadlocks and synchronisation errors.
+- And also in this big PR: a call-back system was developed.
+
+## [v0.0.1] 2025-04-24
+
+- #10 from remove_compiler_warning_changes
+- Remove the compiler warning from CMakeList.txt
+
+## [v0.0.1] 2025-04-27
+
+- The script `snmp_test.sh` gets a 3th test:
+1. Reply to SNMP get request to read the A/B status
+2. Do a complete SNMP walk to see if the data structures are OK [new]
+3. Check if the proper traps are being sent when A/B status changes
+
+

--- a/include/lwip/apps/snmp_opts.h
+++ b/include/lwip/apps/snmp_opts.h
@@ -180,9 +180,9 @@
  * The OID identifiying the device. This may be the enterprise OID itself or any OID located below it in tree.
  */
 #if !defined SNMP_DEVICE_ENTERPRISE_OID || defined __DOXYGEN__
-#define SNMP_LWIP_ENTERPRISE_OID 26381
+#define SNMP_LWIP_ENTERPRISE_OID 62530
 /**
- * IANA assigned enterprise ID for lwIP is 26381
+ * IANA assigned enterprise ID for lwIP is 62530
  * @see http://www.iana.org/assignments/enterprise-numbers
  *
  * @note this enterprise ID is assigned to the lwIP project,
@@ -226,7 +226,7 @@
  * Value return for sysDesc field of MIB2.
  */
 #if !defined SNMP_LWIP_MIB2_SYSDESC || defined __DOXYGEN__
-#define SNMP_LWIP_MIB2_SYSDESC              "lwIP"
+#define SNMP_LWIP_MIB2_SYSDESC              "sysDesc"
 #endif
 
 /**
@@ -234,7 +234,7 @@
  * To make sysName field settable, call snmp_mib2_set_sysname() to provide the necessary buffers.
  */
 #if !defined SNMP_LWIP_MIB2_SYSNAME || defined __DOXYGEN__
-#define SNMP_LWIP_MIB2_SYSNAME              "FQDN-unk"
+#define SNMP_LWIP_MIB2_SYSNAME              "sysName"
 #endif
 
 /**
@@ -242,7 +242,7 @@
  * To make sysContact field settable, call snmp_mib2_set_syscontact() to provide the necessary buffers.
  */
 #if !defined SNMP_LWIP_MIB2_SYSCONTACT || defined __DOXYGEN__
-#define SNMP_LWIP_MIB2_SYSCONTACT           ""
+#define SNMP_LWIP_MIB2_SYSCONTACT           "sysContact"
 #endif
 
 /**
@@ -250,7 +250,7 @@
  * To make sysLocation field settable, call snmp_mib2_set_syslocation() to provide the necessary buffers.
  */
 #if !defined SNMP_LWIP_MIB2_SYSLOCATION || defined __DOXYGEN__
-#define SNMP_LWIP_MIB2_SYSLOCATION          ""
+#define SNMP_LWIP_MIB2_SYSLOCATION          "sysLocation"
 #endif
 
 /**

--- a/src/snmp_callback.c
+++ b/src/snmp_callback.c
@@ -59,20 +59,21 @@ size_t snmp_private_call_handler(const char *prefix, void *value_p)
             
 	/* value is actually an array of SNMP_VALUE_BUFFER_SIZE bytes. */
 	zephyr_log("snmp_private_call_handler: Looking for %s\n", prefix);
-		while (entry != NULL) {
-			if (entry->handler) {
+	while (entry != NULL) {
+		if (entry->handler) {
 			size_t mlength = match_length(prefix, entry->prefix);
 			char special = entry->prefix[mlength-1];
-			zephyr_log("Match \"%s\" %d/%d special = %c\n", entry->prefix, mlength, plength, special);
-			if ((mlength >= plength) || (mlength == strlen (entry->prefix))) {
-					int value = entry->handler(prefix, entry);
-					value_length = sizeof value;
-					memcpy (value_p, &value, value_length);
-					break;
-				}
+			bool does_match = (mlength >= plength) || (mlength == strlen (entry->prefix));
+			zephyr_log("Match %s \"%s\" %d/%d special = %c\n", does_match ? "true" : "false", entry->prefix, mlength, plength, special);
+			if (does_match) {
+				int value = entry->handler(prefix, entry);
+				value_length = sizeof value;
+				memcpy (value_p, &value, value_length);
+				break;
 			}
-			entry = entry->next;
 		}
+		entry = entry->next;
+	}
 	zephyr_log ("snmp_private_call_handler (%s): %sfound\n", prefix, value_length ? "" : "not ");
 	return value_length;
 }

--- a/src/snmp_msg.c
+++ b/src/snmp_msg.c
@@ -527,6 +527,10 @@ snmp_process_varbind(struct snmp_request *request, struct snmp_varbind *vb, u8_t
 		/* When the OID is not found, call the earlier get_value() method. */
 		if ((len == 0) && (node_instance.get_value != NULL)) {
 		  len = node_instance.get_value(&node_instance, vb->object_value);
+		  if (len <= 0) {
+		  	/* Log this event, just for debugging. */
+			  zephyr_log("snmp_process_varbind: no value found for %s\n", ptr);
+		  }
 		}
 	}
     if (len >= 0) {

--- a/src/snmp_zephyr.c
+++ b/src/snmp_zephyr.c
@@ -50,8 +50,8 @@
 #include <zephyr/net/socket_service.h>
 #include <app_version.h>
 
-#include "lwip/apps/snmp_opts.h"
-#include "lwip/apps/snmp_zephyr.h"
+#include <lwip/apps/snmp_opts.h>
+#include <lwip/apps/snmp_zephyr.h>
 
 #if LWIP_SNMP && SNMP_USE_ZEPHYR
 


### PR DESCRIPTION
Made CHANGELOG up-to-date, and completed MIB2 entries.

While testing SNMP walk, I noticed that some entries had a "bindvar" value of a zero-length string. In this PR, these missing  values will be defined as `sysLocation` and `sysContact`.

Beside that, I made CHANGELOG up-to-date. We introduced it this week, and I added entries that date from the beginning in December until today.

Also I cleaned up `snmp_zephyr.h`: some entries are now defined in `snmp_callback.h` which is a more proper location.