### PR TITLE
Update snmp_zephyr and CL.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,26 +8,26 @@ and this project adheres to
 
 ## [unreleased]
 
-## [v0.0.3] - 2025-04-23
+## 2025-04-23
 
 - remove app compiler flags as this was leaking into the main application compile
 
-## [v0.0.2] - 2025-04-23
+## 2025-04-23
 
 - move to a callback for SNMP get requests
 
-## [v0.0.1] - 2025-04-27
+## 2025-04-27
 
 - Tested the MIB's and library by running an SNMP walk. This command iterates through all entries, starting at a certain point, eg. '1':
   Command: `snmpwalk -v2c -c public 192.168.2.17 1`
   It provides an interesting extra test.
 
-## [v0.0.1] - 2025-04-24
+## 2025-04-24
 
 - #10 from remove_compiler_warning_changes
 - Remove the compiler warning from CMakeList.txt
 
-## [v0.0.1] - 2025-04-22
+## 2025-04-22
 
 - #9 from Start_using_socket_service
 - The SNMP port started using the Zephyr socket services
@@ -35,32 +35,32 @@ and this project adheres to
 - The socket services will pass UDP data to the SNMP thread, which will execute the commands and give a reply. The sending of traps happens in the same thread, thus avoiding things like: race conditions, data races, deadlocks and synchronisation errors.
 - And also in this big PR: a call-back system was developed.
 
-## [v0.0.1] - 2025-03-13
+## 2025-03-13
 
 - #8 from Worked_on_snmp_zephyr
 - Removed the check about the network, added snmp_zephyr.h
 
-## [v0.0.1] - 2025-03-13
+## 2025-03-13
 
 - #7 from assume_network_ready_while_init
 - Assume that the zephyr network is up-and-running at start-up. Until now this seems to work OK.
 
-## [v0.0.1] - 2025-02-25
+## 2025-02-25
 
 - #6 from pass_address_network_endian
 - Pass the SNMP trap port number and IP-address in network-endian format
 
-## [v0.0.1] - 2025-01-29
+## 2025-01-29
 
 - #5 from More_logging_more_tested
 - Tested sending traps, also tested the new functions in snmp_zephyr.c
 
-## [v0.0.1] - 2025-01-15
+## 2025-01-15
 
 - #3 from Better_logging_snmp_zephyr
 - Made logging better by showing request OID (Object ID) of requests.
 
-## [v0.0.1] - 2025-01-06
+## 2025-01-06
 
 - PR #1 from added_header_files
 - Added the necessary header files from the latest lwIP release, also started to port the software for Zypher, using it native IP-stack.

--- a/include/lwip/apps/snmp_zephyr.h
+++ b/include/lwip/apps/snmp_zephyr.h
@@ -9,41 +9,6 @@
 extern "C" {
 #endif
 
-/**
- * @brief Definition of a callback function.
- *
- * @param[in] oid The current OID that is requested.
- * @param[in] entry A struct with information about this call-back.
- *
- * @return The return value of the handler will be sent to the requester.
- */
-struct snmp_handler_entry;
-typedef int (*snmp_handler)(const char *oid, struct snmp_handler_entry * entry);
-
-/**
- * @brief Definition of a callback entry.
- *
- */
-struct snmp_handler_entry {
-  snmp_handler handler;            /**< The function that will be called. */
-  const char *prefix;              /**< The IOD for which it will be called. */
-  struct snmp_handler_entry *next; /**< The next handler in an array. */
-};
-
-/**
- * @brief Try to match an OID with the installed handlers.
- *        When a match is found, call the handler function.
- *        This function is private and should only be called from
- *        the SNMP library.
- */
-size_t snmp_private_call_handler(const char *prefix, void *value);
-
-/**
- * @brief Install a new SNMP callback function.
- *
- * @param[in] entry A description of the new callback.
- */
-void install_snmp_handler(struct snmp_handler_entry * entry);
 
 /**
  * @brief Starts SNMP Agent. It assumes that the network is up and
@@ -81,7 +46,10 @@ size_t zephyr_log( const char * format, ... )
 #endif
 ;
 
+/* A user provided function that will wake-up or interrupt any blocking call
+ * and call snmp_recv_packet() to receive an SNMP packet. */
 void snmp_recv_complete(int packet_id);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/snmp_zephyr.c
+++ b/src/snmp_zephyr.c
@@ -90,9 +90,6 @@
 /** Yes, a global variable. */
 	struct udp_pcb * udp_pcbs;
 
-/** The first entry in a linked list of handler entries. */
-	static struct snmp_handler_entry * first_handler;
-
 /** Global variable containing lwIP internal statistics. Add this to your debugger's watchlist. */
 	struct stats_ lwip_stats;
 
@@ -327,7 +324,6 @@ NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(service_udp, udp_service_handler, MAX_SERV
 				}
 			}
 		}
-		first_handler = NULL;
 		return has_sockets;
 	}
 


### PR DESCRIPTION
Update snmp_zephyr.h and CL.md

My earlier PR #11 missed an update of snmp_zephyr.h. The declarations of snmp_callback were moved to a new module snmp_callback.[ch]

Also I changed CHANGELOG.md : I removed the version numbers from the older entries, e.g.
~~~diff
-## [v0.0.1] - 2025-04-27
+## 2025-04-27
~~~
