### PR TITLE
Remove circular reference between SNMP library and a module that uses that library

### DIFF
--- a/include/lwip/apps/snmp_zephyr.h
+++ b/include/lwip/apps/snmp_zephyr.h
@@ -11,10 +11,18 @@ extern "C" {
 
 
 /**
+ * @brief handle incomming requests.
+ *        A call-back will be executed when necessary.
+ */
+typedef void ( * recv_packet_handler )(int packet_id);
+
+/**
  * @brief Starts SNMP Agent. It assumes that the network is up and
  *        running. The UDP sockets will be created.
+ *
+ * @param[in] The address of a function that forwards incoming packets.
  */
-extern int snmp_init(void);
+extern int snmp_zephyr_init(recv_packet_handler handler);
 
 /**
  * @brief handle incomming requests.
@@ -45,10 +53,6 @@ size_t zephyr_log( const char * format, ... )
 	__attribute__ ((format (printf, 1, 2)))
 #endif
 ;
-
-/* A user provided function that will wake-up or interrupt any blocking call
- * and call snmp_recv_packet() to receive an SNMP packet. */
-void snmp_recv_complete(int packet_id);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
The client module, running from the SNMP thread, had to define a function called when a packet is received:

    void snmp_recv_complete(int packet_id);
	
When called, it has to make sure that the application thread will call:

    void snmp_recv_packet(int packet_id);

And the circle is round: module A is calling a function from module B, and vv.

In the presented solution, I will use an installable call-back function. It will be "installed" in `snmp_init_zephyr()`:

    int snmp_init_zephyr(recv_packet_handler user_function);

So now the normal dependency scheme is restored, i.e. the SNMP thread calls the driver, and vv. only by means of an installable callback function, like we have for the get requests.
